### PR TITLE
Use wrapper block to simplify extends

### DIFF
--- a/core-bundle/contao/templates/twig/content_element/headline.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/headline.html.twig
@@ -1,8 +1,6 @@
 {% extends "@Contao/content_element/_base.html.twig" %}
 {% use "@Contao/component/_headline.html.twig" %}
 
-{% block wrapper_tag %}{{ headline.tag_name|default('h1') }}{% endblock %}
-
-{% block inner %}
-    {{- block('headline_inner') -}}
+{% block wrapper %}
+    {{- block('headline_component') -}}
 {% endblock %}


### PR DESCRIPTION
Fixes #6550

With this, extension would be much easier, like @m-vo suggested:
```
{% block headline_attributes %}
        {% set headline = headline|merge({attributes: attrs(headline.attributes|default).addClass(custom_class)}) %}
    {{ parent() }}
{% endblock %}
```
(where custom_class would be added e.g. from the `getContentElement` hook)